### PR TITLE
Uc 5 reg and login using google

### DIFF
--- a/src/app/providers/ui/auth-provider/auth-provider.tsx
+++ b/src/app/providers/ui/auth-provider/auth-provider.tsx
@@ -33,14 +33,17 @@ const AuthProvider = (props: Props) => {
 
   /** При первом запуске Арр */
   useEffect(() => {
-    const accessToken = getStoreLocalStorage('accessToken')
+    const timer = setTimeout(() => {
+      const accessToken = getStoreLocalStorage('accessToken')
 
-    if (!accessToken) {
-      router.push(getAuthUrl('/sign-in'))
-    }
-    // if (accessToken) authMe()
-  }, [])
+      if (!accessToken) {
+        router.push(getAuthUrl('/sign-in'))
+      }
+      // if (accessToken) authMe()
+    }, 500) // Задержка в 500 мс
 
+    return () => clearTimeout(timer)
+  }, [router])
   /** Проверка на рефреш-токен при переходе на др.страницу - если его нет, то logout() */
   useEffect(() => {
     const refreshToken = Cookies.get('refreshToken')

--- a/src/app/providers/ui/auth-provider/auth-provider.tsx
+++ b/src/app/providers/ui/auth-provider/auth-provider.tsx
@@ -33,17 +33,13 @@ const AuthProvider = (props: Props) => {
 
   /** При первом запуске Арр */
   useEffect(() => {
-    const timer = setTimeout(() => {
-      const accessToken = getStoreLocalStorage('accessToken')
+    const accessToken = getStoreLocalStorage('accessToken')
 
-      if (!accessToken) {
-        router.push(getAuthUrl('/sign-in'))
-      }
-      // if (accessToken) authMe()
-    }, 500) // Задержка в 500 мс
-
-    return () => clearTimeout(timer)
-  }, [router])
+    if (!accessToken) {
+      router.push(getAuthUrl('/sign-in'))
+    }
+    // if (accessToken) authMe()
+  }, [])
   /** Проверка на рефреш-токен при переходе на др.страницу - если его нет, то logout() */
   useEffect(() => {
     const refreshToken = Cookies.get('refreshToken')

--- a/src/pages/auth/google-success/index.tsx
+++ b/src/pages/auth/google-success/index.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+
+import { useRouter } from 'next/router'
+
+const GoogleSuccess = () => {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (router.isReady) {
+      const { accessToken } = router.query
+
+      if (accessToken) {
+        localStorage.setItem('accessToken', JSON.stringify({ accessToken: accessToken as string }))
+        router.push('/home')
+      }
+    }
+  }, [router.isReady, router.query])
+
+  return null
+}
+
+export default GoogleSuccess

--- a/src/pages/auth/google-success/index.tsx
+++ b/src/pages/auth/google-success/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 
+import { getAuthUrl } from '@/shared/config/url/api.config'
 import { useRouter } from 'next/router'
 
 const GoogleSuccess = () => {
@@ -11,8 +12,13 @@ const GoogleSuccess = () => {
 
       if (accessToken) {
         localStorage.setItem('accessToken', JSON.stringify({ accessToken: accessToken as string }))
-        router.push('/home')
+        // router.push('/home')
       }
+      setTimeout(() => {
+        router.push('/home')
+      }, 100) // 100 мс
+    } else {
+      router.push(getAuthUrl('/sign-in'))
     }
   }, [router.isReady, router.query])
 


### PR DESCRIPTION
The backend handles Google OAuth2.
When call endpoint https://app.incubatogram.org/api/v1/auth/google endpoint,  backend returns the URL https://incubatogram.org/auth/google-success with id, userName and accessToken.
I created a google-success page and set the accessToken to localstorage and redirect to home. To prevent a premature redirect to /sign-in when the accessToken is missing, I added delay in check to auth-provider.tsx.